### PR TITLE
feature: support controllers by constructor AppWrapper or dynamically…

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,6 @@ import { HttpServer } from "./infrastructure/app/server/HttpServer";
 import errorHandlerMiddleware from "./infrastructure/middleware/error";
 
 const appWrapper = new AppWrapper();
-
 const server = new HttpServer(appWrapper);
 server.start();
 

--- a/src/infrastructure/app/server/HttpServer.ts
+++ b/src/infrastructure/app/server/HttpServer.ts
@@ -18,7 +18,7 @@ export class HttpServer {
         this.server.listen(AppSettings.ServerPort);
       })
       .catch((error) => {
-        console.log("Server error", error);
+        console.log("Server starting error:", error);
       });
 
     this.server.on("listening", () => {

--- a/src/infrastructure/config/index.ts
+++ b/src/infrastructure/config/index.ts
@@ -4,7 +4,7 @@ import * as dotenv from "dotenv";
 const dev = "development";
 
 if (!process?.env?.NODE_ENV) {
-  console.log("Running dev mode");
+  console.log("Running in dev mode");
   dotenv.config();
 }
 


### PR DESCRIPTION
Now the AppWrapper class accept Controllers by constructor and also with the dynamic load added in previous days.

Why this decision?
Because most probably there will be people who will use the Application in Cluster Mode and those who will use it in a normal way, so I try to please both parts and make the Wrapper of the application support both configurations.

However, feel free to modify the template to your liking when you are going to use it.

Application in Cluster Mode (Multi process)

```ts
import { cpus } from "os";
import "express-async-errors";
import * as cluster from "cluster";
import config from "./infrastructure/config";
import AppWrapper from "./infrastructure/app/AppWrapper";
import { HttpServer } from "./infrastructure/app/server/HttpServer";
import errorHandlerMiddleware from "./infrastructure/middleware/error";

// Controllers
import BaseController from "./adapters/controllers/base/Base.controller";
import healthController from "./adapters/controllers/health/Health.controller";
import authController from "./adapters/controllers/auth/Auth.controller";
// End Controllers

const controllers: BaseController[] = [healthController, authController];

function startApp(): void {
  const appWrapper = new AppWrapper(controllers);
  const server = new HttpServer(appWrapper);
  server.start();

  process.on("uncaughtException", (error: NodeJS.UncaughtExceptionListener) => {
    errorHandlerMiddleware.manageNodeException("UncaughtException", error);
  });

  process.on("unhandledRejection", (reason: NodeJS.UnhandledRejectionListener) => {
    errorHandlerMiddleware.manageNodeException("UnhandledRejection", reason);
  });
}

if (cluster.isMaster) {
  const totalCPUs = cpus().length;
  console.log(`Total CPUs are ${totalCPUs}`);
  console.log(`Master process ${process.pid} is running`);

  for (let i = 0; i < totalCPUs; i++) {
    cluster.fork(config.Environment);
  }

  cluster.on("exit", (worker: cluster.Worker, code: number, signal: string) => {
    console.log(`Worker ${worker.process.pid} stopped with code ${code} and signal ${signal}`);
    cluster.fork();
  });
} else {
  startApp();
}
```

Application normal, without Cluster Mode (Single process)

```ts
import "express-async-errors";
import AppWrapper from "./infrastructure/app/AppWrapper";
import { HttpServer } from "./infrastructure/app/server/HttpServer";
import errorHandlerMiddleware from "./infrastructure/middleware/error";

const appWrapper = new AppWrapper();
const server = new HttpServer(appWrapper);
server.start();

process.on("uncaughtException", (error: NodeJS.UncaughtExceptionListener) => {
  errorHandlerMiddleware.manageNodeException("UncaughtException", error);
});

process.on("unhandledRejection", (reason: NodeJS.UnhandledRejectionListener) => {
  errorHandlerMiddleware.manageNodeException("UnhandledRejection", reason);
});
```