### PR TITLE
Feature/cli args improvements

### DIFF
--- a/src/infrastructure/tsk-tools/argsUtils.js
+++ b/src/infrastructure/tsk-tools/argsUtils.js
@@ -1,0 +1,42 @@
+const availableAddUseCaseCommandArgs = [
+  { argName: "api-name", aliases: ["a", "api", "-a", "-api"] },
+  { argName: "use-case", aliases: ["u", "uc", "-u", "-uc"] },
+  { argName: "endpoint", aliases: ["e", "ep", "-e", "-ep"] },
+  {
+    argName: "http-method",
+    aliases: ["m", "h", "hm", "http", "method", "-m", "-h", "-hm", "-http", "-method"],
+  },
+];
+
+function convertArgsToKeyValueArray(args, joinedBy) {
+  if (!args?.length) return [];
+
+  return args.map((arg) => {
+    const [key, value] = arg.split(joinedBy);
+    return { key, value };
+  });
+}
+
+function getArgValue(argName, keyValueArgsArray, availableArgs) {
+  const elegibleArgIndex = availableArgs.findIndex((elegible) => elegible.argName === argName);
+  const elegibleArg = availableArgs[elegibleArgIndex];
+
+  const argIndex = keyValueArgsArray.findIndex(
+    (keyValueArg) =>
+      keyValueArg.key.toLowerCase() === argName ||
+      elegibleArg.aliases.includes(keyValueArg.key.toLowerCase()),
+  );
+  if (argIndex === -1) return null;
+  const argValue = keyValueArgsArray[argIndex].value;
+
+  availableArgs.splice(elegibleArgIndex, 1);
+  keyValueArgsArray.splice(argIndex, 1);
+
+  return argValue;
+}
+
+module.exports = {
+  availableAddUseCaseCommandArgs,
+  convertArgsToKeyValueArray,
+  getArgValue,
+};

--- a/src/infrastructure/tsk-tools/commandHandler.js
+++ b/src/infrastructure/tsk-tools/commandHandler.js
@@ -29,6 +29,7 @@ const EQUAL_CHAR = "=",
   COMMA_SPACE = ", ",
   SPACE_COMMA = " ,",
   COMMA_CHAR = ",",
+  EMPTY_CHAR = "",
   HELP_COMMAND = "help";
 
 const controllerStrategy = {
@@ -152,32 +153,55 @@ const controllerStrategy = {
 };
 
 function addUseCase(args, settingsFile) {
-  const warningMessage =
-    "Missing parameters. Please provide api-name, use-case, endpoint and http-method";
+  const API_NAME_ARG = "api-name";
+  const USE_CASE_ARG = "use-case";
+  const ENDPOINT_ARG = "endpoint";
+  const HTTP_METHOD_ARG = "http-method";
+
+  const warningMessage = "Missing parameters. Please provide {{MissingArgs}} or some alias.";
 
   const keyValueArgsArray = convertArgsToKeyValueArray(args, EQUAL_CHAR);
   if (!keyValueArgsArray.length) {
-    console.warn(warningMessage);
+    console.warn(
+      warningMessage.replace(
+        "{{MissingArgs}}",
+        `${API_NAME_ARG}, ${USE_CASE_ARG}, ${ENDPOINT_ARG} and ${HTTP_METHOD_ARG}`,
+      ),
+    );
     return;
   }
 
-  const apiName = getArgValue("api-name", keyValueArgsArray, availableAddUseCaseCommandArgs);
-  const useCaseName = getArgValue("use-case", keyValueArgsArray, availableAddUseCaseCommandArgs);
+  const apiName = getArgValue(API_NAME_ARG, keyValueArgsArray, availableAddUseCaseCommandArgs);
+  const useCaseName = getArgValue(USE_CASE_ARG, keyValueArgsArray, availableAddUseCaseCommandArgs);
   const endPoint = addCharToStar(
-    getArgValue("endpoint", keyValueArgsArray, availableAddUseCaseCommandArgs).toLowerCase(),
+    getArgValue(ENDPOINT_ARG, keyValueArgsArray, availableAddUseCaseCommandArgs)?.toLowerCase(),
     SLASH_CHAR,
   );
   const httpMethod = getArgValue(
-    "http-method",
+    HTTP_METHOD_ARG,
     keyValueArgsArray,
     availableAddUseCaseCommandArgs,
-  ).toUpperCase();
-  const apiNameCapitalized = capitalize(apiName);
+  )?.toUpperCase();
 
   if (!apiName || !useCaseName || !endPoint || !httpMethod) {
-    console.warn(warningMessage);
+    console.warn(
+      warningMessage.replace(
+        "{{MissingArgs}}",
+        [
+          { key: API_NAME_ARG, value: apiName },
+          { key: USE_CASE_ARG, value: useCaseName },
+          { key: ENDPOINT_ARG, value: endPoint },
+          { key: HTTP_METHOD_ARG, value: httpMethod },
+        ]
+          .filter((arg) => (!arg.value ? arg.key : EMPTY_CHAR))
+          .map((arg) => arg.key)
+          .join(COMMA_SPACE),
+      ),
+    );
     return;
   }
+
+  const apiNameCapitalized = capitalize(apiName);
 
   if (!settingsFile.httpMethodsAllowed.includes(httpMethod.toLowerCase())) {
     console.warn(

--- a/src/infrastructure/tsk-tools/templates.js
+++ b/src/infrastructure/tsk-tools/templates.js
@@ -1,8 +1,11 @@
 const helpDescription = `Serverless TSK available commands:
-  - help
-  > The next command will create a new function into the project
   - add-use-case 'api-name=<apiName> use-case=<useCaseName> endpoint=<endpoint> http-method=<METHOD>'
-  > Example: npm run tsk 'add-use-case api-name=auth use-case=Logout endpoint=/v1/auth/logout http-method=GET'
+    > The previous command will create a new UseCase into the project. Arguments can be sent in any order.
+    > Example: npm run tsk 'add-use-case api-name=auth use-case=Logout endpoint=/v1/auth/logout http-method=GET'
+
+  - alias 'arg=<argName>'
+    > The previous command will show available aliases for the sended argument name
+    > Example: npm run tsk 'alias arg=api-name'
 `;
 
 const importControllerTemplate = "import container, { {{UseCaseName}}UseCase, ";
@@ -12,7 +15,7 @@ const functionControllerTemplate = `
     res: IResponse,
     next: INextFunction,
   ): Promise<void> => {
-    // Create your request data here
+    // Create your request data from body, query or params here
     const body = req.body;
     return this.handleResultData(
       res,
@@ -70,7 +73,8 @@ const useCaseTemplate = `import { BaseUseCase, IResult, Result } from "../../../
 import { ILogProvider } from "../../../../shared/log/providerContracts/ILogProvider";
 import { LocaleTypeEnum } from "../../../../shared/locals/LocaleType.enum";
 import { UseCaseTrace } from "../../../../shared/log/UseCaseTrace";
-//TODO: Change this input generic type BaseUseCase<unknown>
+
+//TODO: Change this input generic type BaseUseCase<unknown> according input of your use case
 export class {{UseCaseName}}UseCase extends BaseUseCase<unknown> {
   constructor(
     readonly logProvider: ILogProvider,


### PR DESCRIPTION
- Command to create a use case now support any order, for example:
```console
npm run tsk 'add-use-case -a=Logout -e=/v1/auth/logout -h=get a=auth'
```
- Arguments for create a use case now support aliases. You can saw it in te previous command, but to see it you can execute.
```console
npm run tsk 'alias arg=http-method'
```
- Some posible bugs for CLI function to create a use case were fixed
