### PR TITLE
ObjectPropertyUtil in buildRequest assign options properties to origin

### DIFF
--- a/src/infrastructure/httpClient/HttpClient.ts
+++ b/src/infrastructure/httpClient/HttpClient.ts
@@ -19,13 +19,13 @@ export class HttpClient extends BaseHttpClient {
     method: string,
     body?: BodyType,
     headers?: Headers,
-    options?: RequestInit,
+    options: RequestInit = {},
   ): Request {
     const origin = { method, body, headers };
-    if (!options) options = {};
-    ObjectPropertyUtil.assign(options, origin, "method");
-    ObjectPropertyUtil.assign(options, origin, "body");
-    ObjectPropertyUtil.assign(options, origin, "headers");
+
+    ObjectPropertyUtil.assign(origin, options, "method");
+    ObjectPropertyUtil.assign(origin, options, "body");
+    ObjectPropertyUtil.assign(origin, options, "headers");
 
     return new Request(url, options);
   }


### PR DESCRIPTION
### Issue Description

**Problem:** The `ObjectPropertyUtil` utility is incorrectly assigning properties from the `options` parameter to the `origin` object when calling `ObjectPropertyUtil.assign(options, origin, "body");`.

**Expected Behavior:** The utility should assign properties from the `origin` object to the `options` parameter, following the expected method call `ObjectPropertyUtil.assign(origin, options, "body");`.

**Current Code:**
```javascript
ObjectPropertyUtil.assign(options, origin, "body");
```
**Correct Code:**
```javascript
ObjectPropertyUtil.assign(origin, options, "body");
```

